### PR TITLE
Added the ability to auth without creds and fixed forcing the source …

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,11 +175,5 @@ func validateGenericRegistry(r Registry) error {
 	if r.GENERIC.Repository == "" {
 		return errorWithType(r, `requires a field "repository"`)
 	}
-	if r.GENERIC.Username == "" {
-		return errorWithType(r, `requires a field "username"`)
-	}
-	if r.GENERIC.Password == "" {
-		return errorWithType(r, `requires a field "password"`)
-	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -314,9 +314,7 @@ func TestGenericRegistryNoUsername(t *testing.T) {
 	genericRegistry.GENERIC.Username = ""
 
 	err = CheckRegistryConfiguration(genericRegistry)
-	assert.NotNil(t, err)
-	assert.Equal(t, "registry of type \"generic\" requires a field \"username\"", err.Error())
-
+	assert.Nil(t, err)
 }
 
 func TestGenericRegistryNoPassword(t *testing.T) {
@@ -330,9 +328,7 @@ func TestGenericRegistryNoPassword(t *testing.T) {
 	genericRegistry.GENERIC.Password = ""
 
 	err = CheckRegistryConfiguration(genericRegistry)
-	assert.NotNil(t, err)
-	assert.Equal(t, "registry of type \"generic\" requires a field \"password\"", err.Error())
-
+	assert.Nil(t, err)
 }
 
 func TestGCPRegistryNoLocation(t *testing.T) {

--- a/pkg/registry/generic_test.go
+++ b/pkg/registry/generic_test.go
@@ -219,7 +219,7 @@ func TestDockerConfigSuccess(t *testing.T) {
 
 	for key, authConfig := range dockerConfig.AuthConfigs {
 		assert.Equal(t, "localhost", key)
-		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("password")), authConfig.Auth)
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("user:password")), authConfig.Auth)
 	}
 }
 


### PR DESCRIPTION
…repositories being defined in config

Made the changes less mandatory so now you can get images without setting auth. Works well with in-cluster registry that doesn't really needs creds.

You can test the behavior using docker.io/inputobject2/k8s-image-swapper:v1.5.9-noauth if you want.